### PR TITLE
Show absolute paths for list output

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -62,15 +62,19 @@ ensure_init() {
 list_services() {
   echo "Verfügbare Services (*.tfvars):"
   if [ -d "$SERVICES_DIR" ]; then
-    find "$SERVICES_DIR" -maxdepth 1 -type f -name "*.tfvars" -print 2>/dev/null | sort | sed "s|$SERVICES_DIR/|  |" || true
+    while IFS= read -r -d '' file; do
+      echo "  $(realpath "$file")"
+    done < <(find "$SERVICES_DIR" -maxdepth 1 -type f -name "*.tfvars" -print0 2>/dev/null | sort -z) || true
   else
     echo "  (Verzeichnis '$SERVICES_DIR' nicht gefunden)"
   fi
 
   echo
-  echo "Verfügbare Skripte:" 
+  echo "Verfügbare Skripte:"
   if [ -d "$SCRIPTS_DIR" ]; then
-    find "$SCRIPTS_DIR" -type f -name "*.sh" -print 2>/dev/null | sort | sed "s|$SCRIPTS_DIR/|  |" || true
+    while IFS= read -r -d '' file; do
+      echo "  $(realpath "$file")"
+    done < <(find "$SCRIPTS_DIR" -type f -name "*.sh" -print0 2>/dev/null | sort -z) || true
   else
     echo "  (Verzeichnis '$SCRIPTS_DIR' nicht gefunden)"
   fi


### PR DESCRIPTION
## Summary
- update the `list` subcommand to print absolute paths for services and helper scripts
- ensure results stay sorted while iterating through `find` output safely

## Testing
- ./runner.sh list

------
https://chatgpt.com/codex/tasks/task_e_68d3e4a0bd348333b7fd4cbe0b949077